### PR TITLE
like and dislike specific comment

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -647,6 +647,67 @@ paths:
                       message:
                           type: string
                           example: 'user not found'
+  /novels/{commentId}/like:
+    post:
+      summary: Creates a comment
+      description: Post a comment on a novel
+      parameters:
+        - name: commentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: succesful request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: you've successfully liked comment
+        401:
+          description: unauthorized access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: invalid token
+        403:
+          description: forbidden access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: you have to be subscribed to like a comment
+        404:
+          description: entity not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: comment not found
+        500:
+          description: server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: error occured
   /novels/{slug}/comments/{parentId}:
     post:
       summary: Creates a reply

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -6,7 +6,8 @@ const {
   novelServices: { findNovel },
   notificationServices: { addNotification },
   commentServices: {
-    findComment, createComment, updateComment, getOldComments, insertEditedComment
+    findComment, createComment, updateComment, getOldComments,
+    insertEditedComment, createCommentLike, findCommentLike, deleteCommentLike
   },
 } = services;
 
@@ -137,7 +138,25 @@ const editComment = async (req, res) => {
   }
 };
 
+const likeComment = async (request, response) => {
+  const { user: { id: userId }, params: { commentId } } = request;
+  try {
+    const commentExist = await findComment(commentId);
+    if (!commentExist) {
+      return responseMessage(response, 404, { error: 'comment does not exist' });
+    }
+    const likeExist = await findCommentLike(userId, commentId);
+    if (likeExist) {
+      await deleteCommentLike(userId, commentId);
+      return responseMessage(response, 200, { message: 'you\'ve successfully unliked this comment' });
+    }
+    await createCommentLike(userId, commentId);
+    return responseMessage(response, 200, { message: 'you\'ve successfully liked this comment' });
+  } catch (error) {
+    return responseMessage(response, 500, { error: error.message });
+  }
+};
 
 export default {
-  postComment, replyComment, fetchCommentHistory, editComment
+  postComment, replyComment, likeComment, fetchCommentHistory, editComment
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -33,6 +33,7 @@ const signUp = async (req, res) => {
   };
 
   const createdUser = await User.create(user);
+
   await verifyUser({
     id: createdUser.id,
     email: createdUser.email,

--- a/src/database/migrations/20190811124707-create-comment-like.js
+++ b/src/database/migrations/20190811124707-create-comment-like.js
@@ -1,0 +1,22 @@
+export const up = (queryInterface, Sequelize) => queryInterface.createTable('CommentLikes', {
+  id: {
+    allowNull: false,
+    primaryKey: true,
+    type: Sequelize.UUID
+  },
+  userId: {
+    type: Sequelize.UUID
+  },
+  commentId: {
+    type: Sequelize.UUID
+  },
+  createdAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  }
+});
+export const down = queryInterface => queryInterface.dropTable('CommentLikes');

--- a/src/database/models/comment.js
+++ b/src/database/models/comment.js
@@ -43,6 +43,10 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'parentId',
       onDelete: 'CASCADE'
     });
+    Comment.hasMany(models.CommentLike, {
+      foreignKey: 'commentId',
+      onDelete: 'CASCADE'
+    });
   };
   return Comment;
 };

--- a/src/database/models/commentlike.js
+++ b/src/database/models/commentlike.js
@@ -1,0 +1,29 @@
+export default (sequelize, DataTypes) => {
+  const CommentLike = sequelize.define('CommentLike', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    userId: {
+      allowNull: false,
+      type: DataTypes.UUID
+    },
+    commentId: {
+      allowNull: false,
+      type: DataTypes.UUID
+    },
+  }, {});
+  CommentLike.associate = (models) => {
+    CommentLike.belongsTo(models.Comment, {
+      foreignKey: 'commentId',
+      onDelete: 'CASCADE'
+    });
+    CommentLike.belongsTo(models.User, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE'
+    });
+  };
+  return CommentLike;
+};

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -110,6 +110,10 @@ export default (Sequelize, DataTypes) => {
 
     User.hasMany(models.Follower, {
       foreignKey: 'followeeId',
+    });
+
+    User.hasOne(models.CommentLike, {
+      foreignKey: 'userId',
       onDelete: 'CASCADE'
     });
 

--- a/src/routes/comment.js
+++ b/src/routes/comment.js
@@ -4,10 +4,11 @@ import middlewares from '../middlewares';
 
 const comment = express.Router();
 const COMMENT_URL = '/novels/:slug/comments';
+const CommentLikeUrl = '/comment/:commentId/like';
 
 const { verifyToken, commentValidator, authorizeUser } = middlewares;
 const {
-  postComment, replyComment, fetchCommentHistory, editComment
+  postComment, replyComment, fetchCommentHistory, editComment, likeComment
 } = commentController;
 
 // Route to create a comment
@@ -19,5 +20,5 @@ comment.post(`${COMMENT_URL}/:parentId`, verifyToken, commentValidator.replyComm
 // comment history
 comment.get(`${COMMENT_URL}/:commentId`, verifyToken, commentValidator.getEditedComment, fetchCommentHistory);
 comment.patch(`${COMMENT_URL}/:commentId`, verifyToken, commentValidator.editComment, editComment);
-
+comment.post(`${CommentLikeUrl}`, verifyToken, likeComment);
 export default comment;

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -1,6 +1,7 @@
+import { Op } from 'sequelize';
 import models from '../database/models';
 
-const { Comment, CommentHistory } = models;
+const { Comment, CommentHistory, CommentLike } = models;
 
 /**
  * Finds a comment from the database by id
@@ -64,6 +65,32 @@ const insertEditedComment = async (commentId, commentBody) => {
  */
 const getOldComments = commentId => CommentHistory.findAll({ where: { commentId } });
 
+const createCommentLike = async (userId, commentId) => {
+  await CommentLike.create({
+    userId,
+    commentId
+  });
+};
+
+const findCommentLike = async (userId, commentId) => CommentLike.findOne({
+  where: {
+    [Op.and]: [{ userId }, { commentId }]
+  }
+});
+
+const deleteCommentLike = async (userId, commentId) => CommentLike.destroy({
+  where: {
+    [Op.and]: [{ userId }, { commentId }]
+  }
+});
+
 export default {
-  findComment, createComment, updateComment, getOldComments, insertEditedComment
+  findComment,
+  createComment,
+  createCommentLike,
+  findCommentLike,
+  deleteCommentLike,
+  updateComment,
+  getOldComments,
+  insertEditedComment
 };


### PR DESCRIPTION
#### What does this PR do?
- authenticated users can like specific comment
#### Description of Task to be completed?
- create a comment-like table containing user id and comment id
- create an endpoint that updates comment likes table on like and unlike
#### How should this be manually tested?
To test manually on your local computer:
-  run the following commands.
```
# Clone this repository
$ git clone https://github.com/andela/dahlia-ah-backend.git

# Navigate to the application folder
$ cd dahlia-ah-backend

# Checkout the branch
$ git checkout feature/167165003/user-like-specific-comment

# Install dependencies
$ npm install

# Start the app in development mode
$ npm run dev:start
```
- on Postman make an authorized request to `POST /api/v1/comment/<commentId>/like`

#### What are the relevant pivotal tracker stories?
[#167165003](https://www.pivotaltracker.com/story/show/167165003)

#### Relevant screenshots
<img width="380" alt="Screenshot 2019-08-26 at 12 04 50 PM" src="https://user-images.githubusercontent.com/47520577/63686432-c35dcf80-c7f9-11e9-86a8-a47d80af1b7b.png">


