### PR TITLE
 #167165008 Comment should be able to track edit history

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -676,6 +676,199 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  error:
+                    type: string
+                    example: error occured
+  /novels/{slug}/comments/{commentId}:
+    patch:
+      tags:
+      - Comments
+      summary: Edit comment
+      description: Edit comment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                commentBody:
+                  type: string
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: commentId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        201:
+          description: succesful request, edited
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                      updatedAt:
+                        type: string
+                        example: '2019-08-05T14:17:58.518Z'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                          example: commentBody
+                        message:
+                          type: string
+                          example: commentBody cannot be empty
+        401:
+          description: unauthorized access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: invalid token
+        403:
+          description: forbidden access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: you have to be subscribed to edit a comment
+        404:
+          description: entity not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: no comment found with the provided id
+    get:
+      tags:
+      - Comments
+      summary: Comments edit history
+      description: Comment edit history
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                commentBody:
+                  type: string
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: commentId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        201:
+          description: succesful request, get comments edit history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                      updatedAt:
+                        type: string
+                        example: '2019-08-05T14:17:58.518Z'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                          example: commentBody
+                        message:
+                          type: string
+                          example: commentBody cannot be empty
+        401:
+          description: unauthorized access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: invalid token
+        403:
+          description: forbidden access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: you have to be subscribed to edit a comment
+        404:
+          description: entity not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: no comment found with the provided id
+
+  /auth/logout:
+    get:
+      tags:
+        - Users
+      summary: Logs out a user
+      responses:
+        200:
+          description: Logout was successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Logout was successful
+        401:
+          description: unauthorised request
+        500:
+          description: internal server error
+                  
 components:
   schemas:
     token:

--- a/src/database/migrations/20190814161831-create-comment-history.js
+++ b/src/database/migrations/20190814161831-create-comment-history.js
@@ -1,0 +1,22 @@
+export const up = (queryInterface, Sequelize) => queryInterface.createTable('CommentHistories', {
+  id: {
+    allowNull: false,
+    primaryKey: true,
+    type: Sequelize.UUID
+  },
+  commentId: {
+    type: Sequelize.STRING
+  },
+  commentBody: {
+    type: Sequelize.STRING
+  },
+  createdAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  }
+});
+export const down = queryInterface => queryInterface.dropTable('CommentHistories');

--- a/src/database/models/commenthistory.js
+++ b/src/database/models/commenthistory.js
@@ -1,0 +1,25 @@
+export default (sequelize, DataTypes) => {
+  const CommentHistory = sequelize.define('CommentHistory', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    commentId: {
+      allowNull: false,
+      type: DataTypes.UUID,
+    },
+    commentBody: {
+      allowNull: false,
+      type: DataTypes.STRING
+    }
+  }, {});
+  CommentHistory.associate = (models) => {
+    CommentHistory.belongsTo(models.Comment, {
+      foreignKey: 'commentId',
+      onDelete: 'CASCADE'
+    });
+  };
+  return CommentHistory;
+};

--- a/src/database/seeders/20190806253031-comment.js
+++ b/src/database/seeders/20190806253031-comment.js
@@ -6,12 +6,22 @@ export const up = queryInterface => queryInterface.bulkInsert('Comments', [{
   parentId: null,
   createdAt: new Date(),
   updatedAt: new Date()
-}, {
+},
+{
   id: 'b84f246f-ba18-4f83-876d-145be90b494d',
   commentBody: 'Yeah I think the same',
   userId: '122a0d86-8b78-4bb8-b28f-8e5f7811c456',
   novelId: null,
   parentId: '6a7b986e-1102-4e9a-83b0-cad7df993e1c',
+  createdAt: new Date(),
+  updatedAt: new Date()
+},
+{
+  id: '5de099c5-22d4-4e88-885b-1fd7374d7d5c',
+  commentBody: 'fresh like today bread',
+  userId: '122a0d86-8b78-4bb8-b28f-8e5f7811c456',
+  novelId: '7f45df6d-7003-424f-86ec-1e2b36e2fd14',
+  parentId: null,
   createdAt: new Date(),
   updatedAt: new Date()
 }], {});

--- a/src/database/seeders/20190815091232-comment-history.js
+++ b/src/database/seeders/20190815091232-comment-history.js
@@ -1,0 +1,28 @@
+export const up = queryInterface => queryInterface.bulkInsert('CommentHistories', [{
+  id: 'b984fb1d-faa8-43aa-bfcd-b7e27a94342c',
+  commentBody: 'This is novel is so nice',
+  commentId: '6a7b986e-1102-4e9a-83b0-cad7df993e1c',
+  createdAt: new Date(),
+  updatedAt: new Date()
+}, {
+  id: '057477bc-5f50-447e-90d9-e3e39e24da5f',
+  commentBody: 'Yeah I think the same',
+  commentId: '6a7b986e-1102-4e9a-83b0-cad7df993e1c',
+  createdAt: new Date(),
+  updatedAt: new Date()
+},
+{
+  id: 'b4a15d61-669c-4bad-b9b7-8b5b7afa8106',
+  commentBody: 'No I do not think so',
+  commentId: 'b84f246f-ba18-4f83-876d-145be90b494d',
+  createdAt: new Date(),
+  updatedAt: new Date()
+},
+{
+  id: 'be145307-1763-459f-8ea0-aff7bf84a078',
+  commentBody: '',
+  commentId: 'b84f246f-ba18-4f83-876d-145be90b494d',
+  createdAt: new Date(),
+  updatedAt: new Date()
+}], {});
+export const down = queryInterface => queryInterface.bulkDelete('CommentHistories', null, {});

--- a/src/middlewares/commentValidator.js
+++ b/src/middlewares/commentValidator.js
@@ -20,6 +20,15 @@ const commentValidator = {
     isValidUUID('parentId'),
     isValidComment(),
     validatorError
+  ],
+  editComment: [
+    isValidComment(),
+    isValidUUID('commentId'),
+    validatorError
+  ],
+  getEditedComment: [
+    isValidUUID('commentId'),
+    validatorError
   ]
 };
 

--- a/src/routes/comment.js
+++ b/src/routes/comment.js
@@ -6,12 +6,18 @@ const comment = express.Router();
 const COMMENT_URL = '/novels/:slug/comments';
 
 const { verifyToken, commentValidator, authorizeUser } = middlewares;
-const { postComment, replyComment } = commentController;
+const {
+  postComment, replyComment, fetchCommentHistory, editComment
+} = commentController;
 
 // Route to create a comment
 comment.post(`${COMMENT_URL}`, verifyToken, commentValidator.postComment, authorizeUser(['author', 'admin', 'superadmin']), postComment);
 
 // Route to reply a comment
 comment.post(`${COMMENT_URL}/:parentId`, verifyToken, commentValidator.replyComment, authorizeUser(['author', 'admin', 'superadmin']), replyComment);
+
+// comment history
+comment.get(`${COMMENT_URL}/:commentId`, verifyToken, commentValidator.getEditedComment, fetchCommentHistory);
+comment.patch(`${COMMENT_URL}/:commentId`, verifyToken, commentValidator.editComment, editComment);
 
 export default comment;

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -1,6 +1,6 @@
 import models from '../database/models';
 
-const { Comment } = models;
+const { Comment, CommentHistory } = models;
 
 /**
  * Finds a comment from the database by id
@@ -28,6 +28,42 @@ const createComment = async (commentBody, userId, parentId, novelId) => {
   return createdComment;
 };
 
+/**
+ * Update a comment in the database
+ * @param {string} param
+ * @returns {object} a user object
+ */
+
+const updateComment = async (commentId, commentBody) => {
+  const updatedComment = await Comment.update(
+    { commentBody },
+    {
+      where: { id: commentId },
+      returning: true,
+      raw: true
+    }
+  );
+  const commentUpdate = updatedComment[1][0];
+  return commentUpdate;
+};
+
+/**
+ * insert edited comment in the database
+ * @param {string} commentId
+* @param {string} commentBody
+ * @returns {object} a user object
+ */
+const insertEditedComment = async (commentId, commentBody) => {
+  const insertedComment = await CommentHistory.create({ commentId, commentBody });
+  return insertedComment;
+};
+
+/**
+ * @param {string} commentId
+ * @returns {object} json
+ */
+const getOldComments = commentId => CommentHistory.findAll({ where: { commentId } });
+
 export default {
-  findComment, createComment
+  findComment, createComment, updateComment, getOldComments, insertEditedComment
 };


### PR DESCRIPTION
#### Pivotal Tracker Story

[ #167165008](https://www.pivotaltracker.com/story/show/167165008)

#### What does this PR do?
user can track comments edit history
user can edit a comment

#### Summary of Task
![API Flowchart commenthistory](https://user-images.githubusercontent.com/22136398/63574581-fb59de00-c57f-11e9-96e8-0b204fd25b39.png)






 - add an endpoint for a user to view the previous comments from comments edit history
 - add an endpoint to edit a comment
- write tests to cover various edge cases
 ### How can this be tested?
- git clone branch ` feature/167165008/track-edit-history`
- install dependencies
- run npm install
- start dev server npm run dev:start

#### Screenshots (if appropriate)
<img width="1080" alt="Screenshot 2019-08-19 at 8 54 02 PM" src="https://user-images.githubusercontent.com/22136398/63294972-8195cc00-c2c3-11e9-819d-63b7eb958680.png">

<img width="1158" alt="Screenshot 2019-08-19 at 8 54 43 PM" src="https://user-images.githubusercontent.com/22136398/63295028-9d00d700-c2c3-11e9-97a1-c761f0fb0de2.png">
