### PR TITLE
#167165004 view and add read stats

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -28,6 +28,8 @@ tags:
   description: Operations available for Admin and Super-admin
 - name: Auth
   description: Register and login operations
+- name: Profiles
+  description: User profiles
 
 paths:
   /users:
@@ -1746,7 +1748,75 @@ paths:
         404:
           description: Not found
         500:
-          description: internal server error   
+          description: internal server error
+  /profiles/readingstats:
+    get:
+      tags: 
+        - Profiles
+      summary: Get all reading stats of user
+      security: 
+      - ApiKeyAuth: []
+      parameters:
+      - name: "period"
+        in: "query"
+        description: "time period in days"
+        required: false
+        schema:
+          type: string
+          example: 30
+      responses:
+        200:
+          description: reading stats of user fetched successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadStats'
+        403:
+          description: not permitted
+        404:
+          description: not found
+        500:
+          description: database error
+  /novels/{slug}/markread:
+    patch:
+      tags:
+      - Novels
+      summary: Mark/remove a novel as read
+      description: Reply a parent comment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                commentBody:
+                  type: string
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 'hancock-424f-86ec-1e2b36e2fd14'
+        - name: readStatus
+          in: path
+          required: true
+          schema:
+            type: string
+            example: true
+            
+      responses:
+        200:
+          description: marked/removed as read successfully
+        400:
+          description: input validation error
+        401:
+          description: authorization error
+        403:
+          description: not permitted
+        500:
+          description: database error
+  
                   
 components:
   schemas:
@@ -2001,6 +2071,46 @@ components:
         roleName:
           type: string
           example: author
+    ReadStats:
+      type: object
+      properties:
+        message:
+          type: string
+          example: success
+        readingStats:
+          type: object
+          properties:
+            bookmarks:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  novelId:
+                    type: string
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+            reads:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  userId:
+                    type: string
+                  novelId:
+                    type: string
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+            countRead:
+              type: integer
+              example: 2
   
   securitySchemes:
     token:

--- a/src/controllers/novelController.js
+++ b/src/controllers/novelController.js
@@ -1,7 +1,10 @@
 import Sequelize from 'sequelize';
+import debug from 'debug';
 import models from '../database/models';
 import services from '../services';
 import helpers from '../helpers';
+
+const log = debug('dev');
 
 const { Op } = Sequelize;
 const {
@@ -13,7 +16,7 @@ const {
     addNovel, findGenre, findNovel, findAllNovels,
     highlightNovelText, getNovelHighlights,
     findNovelById, bookmarkNovel, getAllBookmark,
-    updateNovel, removeNovel
+    updateNovel, removeNovel, toggleReadStatus
   },
   notificationServices: { addNotification }
 } = services;
@@ -311,6 +314,29 @@ const deleteNovel = async (request, response) => {
   }
 };
 
+/**
+ * @description returns novel with slug
+ * @param {object} request express request object
+ * @param {object} response express response object
+ * @param {object} next express next argument
+ * @returns {json} json
+ */
+const toggleRead = async (request, response) => {
+  const { slug } = request.params;
+  const { readStatus } = request.body;
+  try {
+    const novel = await findNovel(slug);
+    if (!novel) {
+      return responseMessage(response, 404, { error: 'novel not found' });
+    }
+    const status = await toggleReadStatus(request.user.id, novel.id, readStatus);
+    return responseMessage(response, 200, { message: status, novel });
+  } catch (error) {
+    log(error.message);
+    responseMessage(response, 500, { error: 'an error occurred' });
+  }
+};
+
 export default {
   createNovel,
   getNovels,
@@ -321,5 +347,6 @@ export default {
   postBookmark,
   fetchBookmarks,
   editNovel,
-  deleteNovel
+  deleteNovel,
+  toggleRead
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -10,7 +10,7 @@ const {
 } = helpers;
 const {
   userServices: {
-    findUser, findFollower, getAllUsers, addUser, findUserRole
+    findUser, findFollower, getAllUsers, addUser, findUserRole, fetchReadStats
   }
 } = services;
 const { User, Follower } = models;
@@ -362,8 +362,26 @@ const deleteUser = async (req, res) => {
 
     return responseMessage(res, 200, { message });
   } catch (error) {
-    log(error);
+    log(error.message);
     return responseMessage(res, 500, { error: 'an error occurred' });
+  }
+};
+
+/**
+ * @description updates the profile of a user
+ * @param {object} request express request object
+ * @param {object} response express response object
+ * @returns {json} json
+ */
+const getReadingStats = async (request, response) => {
+  const { period } = request.query;
+  try {
+    const readingStats = await fetchReadStats(request.user.id, period);
+    const data = { message: 'success', readingStats };
+    return responseMessage(response, 200, data);
+  } catch (error) {
+    log(error.message);
+    return responseMessage(response, 500, { error: 'an error occurred' });
   }
 };
 
@@ -379,5 +397,6 @@ export default {
   createUser,
   getUser,
   updateUser,
-  deleteUser
+  deleteUser,
+  getReadingStats
 };

--- a/src/database/migrations/20190816065005-create-read-stats.js
+++ b/src/database/migrations/20190816065005-create-read-stats.js
@@ -1,0 +1,37 @@
+export const up = (queryInterface, Sequelize) => queryInterface.createTable('readStats', {
+  id: {
+    primaryKey: true,
+    allowNull: false,
+    type: Sequelize.UUID,
+    defaultValue: Sequelize.UUIDV4
+  },
+  userId: {
+    allowNull: false,
+    type: Sequelize.UUID,
+    onDelete: 'CASCADE',
+    defaultValue: Sequelize.UUIDV4,
+    references: {
+      model: 'Users',
+      key: 'id'
+    },
+  },
+  novelId: {
+    allowNull: false,
+    type: Sequelize.UUID,
+    onDelete: 'CASCADE',
+    defaultValue: Sequelize.UUIDV4,
+    references: {
+      model: 'Novels',
+      key: 'id'
+    },
+  },
+  createdAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  }
+});
+export const down = queryInterface => queryInterface.dropTable('readStats');

--- a/src/database/models/novel.js
+++ b/src/database/models/novel.js
@@ -66,6 +66,10 @@ export default (Sequelize, DataTypes) => {
     Novel.belongsTo(models.Genre, {
       foreignKey: 'genreId'
     });
+    Novel.hasMany(models.readStats, {
+      foreignKey: 'novelId',
+      onDelete: 'CASCADE'
+    });
   };
   return Novel;
 };

--- a/src/database/models/readstats.js
+++ b/src/database/models/readstats.js
@@ -1,0 +1,50 @@
+export default (sequelize, DataTypes) => {
+  const readStats = sequelize.define('readStats', {
+    id: {
+      primaryKey: true,
+      allowNull: false,
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4
+    },
+    userId: {
+      allowNull: false,
+      type: DataTypes.UUID,
+      onDelete: 'CASCADE',
+      defaultValue: DataTypes.UUIDV4,
+      references: {
+        model: 'Users',
+        key: 'id'
+      }
+    },
+    novelId: {
+      allowNull: false,
+      type: DataTypes.UUID,
+      onDelete: 'CASCADE',
+      defaultValue: DataTypes.UUIDV4,
+      references: {
+        model: 'Novels',
+        key: 'id'
+      },
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE
+    }
+  }, {});
+  readStats.associate = (models) => {
+    // associations can be defined here
+    readStats.belongsTo(models.User, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+    });
+    readStats.belongsTo(models.Novel, {
+      foreignKey: 'novelId',
+      onDelete: 'CASCADE',
+    });
+  };
+  return readStats;
+};

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -140,6 +140,11 @@ export default (Sequelize, DataTypes) => {
       foreignKey: 'userId',
       onDelete: 'CASCADE'
     });
+
+    User.hasMany(models.readStats, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE'
+    });
   };
   return User;
 };

--- a/src/database/seeders/20190819074127-readStats.js
+++ b/src/database/seeders/20190819074127-readStats.js
@@ -1,0 +1,33 @@
+const novelId1 = '7f45df6d-7003-424f-86ec-1e2b36e2fd14';
+const novelId2 = '8bd8c0ec-3b50-4228-bb71-e617c7b8d3b5';
+const userId1 = '122a0d86-8b78-4bb8-b28f-8e5f7811c456';
+const userId2 = '0ce36391-2c08-4703-bddb-a4ea8cccbbc5';
+const now = Date.now();
+const currentDate = new Date(null);
+const daysToDate = days => parseInt(currentDate.setTime(now - (86400 * 1000 * days)), 10);
+
+const tenDays = daysToDate(10);
+const twentyDays = daysToDate(20);
+const thirtyOneDays = daysToDate(31);
+
+
+export const up = queryInterface => queryInterface.bulkInsert('readStats', [{
+  id: '55868c7c-1fc7-483b-b535-39f2496c2adc',
+  userId: userId1,
+  novelId: novelId1,
+  createdAt: new Date(tenDays),
+  updatedAt: new Date()
+}, {
+  id: '3853f342-71c6-473a-b545-fa4bb4fb43fb',
+  userId: userId1,
+  novelId: novelId2,
+  createdAt: new Date(twentyDays),
+  updatedAt: new Date()
+}, {
+  id: '48b9e5b8-1ade-4e62-ae78-fcfaa4d79132',
+  userId: userId2,
+  novelId: novelId1,
+  createdAt: new Date(thirtyOneDays),
+  updatedAt: new Date()
+}], {});
+export const down = queryInterface => queryInterface.bulkDelete('readStats', null, {});

--- a/src/database/seeders/20190820071336-bookmark.js
+++ b/src/database/seeders/20190820071336-bookmark.js
@@ -1,0 +1,18 @@
+const novelId1 = '7f45df6d-7003-424f-86ec-1e2b36e2fd14';
+const novelId2 = '8bd8c0ec-3b50-4228-bb71-e617c7b8d3b5';
+const userId1 = '122a0d86-8b78-4bb8-b28f-8e5f7811c456';
+
+export const up = queryInterface => queryInterface.bulkInsert('Bookmarks', [{
+  id: 'd54d5aaa-f843-4cb1-b725-8cf6b9ea1a39',
+  userId: userId1,
+  novelId: novelId1,
+  createdAt: new Date(),
+  updatedAt: new Date()
+}, {
+  id: 'bd450c18-8484-4c1a-b124-384c097c2297',
+  userId: userId1,
+  novelId: novelId2,
+  createdAt: new Date(),
+  updatedAt: new Date()
+}], {});
+export const down = queryInterface => queryInterface.bulkDelete('Bookmarks', null, {});

--- a/src/helpers/validator.js
+++ b/src/helpers/validator.js
@@ -233,8 +233,6 @@ const isValidReadInput = field => check(field)
   .exists()
   .withMessage(`${field} is a required field`)
   .trim()
-  .not()
-  .isEmpty()
   .withMessage(`${field} cannot be empty`)
   .isIn(['true', 'false'])
   .withMessage(`${field} can only contain true or false`);

--- a/src/helpers/validator.js
+++ b/src/helpers/validator.js
@@ -225,6 +225,20 @@ const isValidRoleName = field => check(field)
   .isIn(['reader', 'author', 'admin', 'superadmin'])
   .withMessage(`${field} can only be one of: 'reader', 'author', 'admin', 'superadmin'`);
 
+/**
+   * @param {String} field
+   * @returns {Object} - Express-validator
+   */
+const isValidReadInput = field => check(field)
+  .exists()
+  .withMessage(`${field} is a required field`)
+  .trim()
+  .not()
+  .isEmpty()
+  .withMessage(`${field} cannot be empty`)
+  .isIn(['true', 'false'])
+  .withMessage(`${field} can only contain true or false`);
+
 export default {
   isValidEmail,
   isValidName,
@@ -245,5 +259,6 @@ export default {
   isValidPhoneNumber,
   isValidSubcription,
   isValidRoleName,
-  isValidPasswords
+  isValidPasswords,
+  isValidReadInput
 };

--- a/src/middlewares/novelValidator.js
+++ b/src/middlewares/novelValidator.js
@@ -2,7 +2,7 @@ import validator from '../helpers/validator';
 import errorHandler from './errorHandler';
 
 const {
-  isNotEmpty, isValidGenre, isValidInt, isValidName, isNotEmptySlug, isOptional
+  isNotEmpty, isValidGenre, isValidInt, isValidName, isNotEmptySlug, isOptional, isValidReadInput
 } = validator;
 
 const { validatorError } = errorHandler;
@@ -43,6 +43,10 @@ const novelValidator = {
     isNotEmpty('keyword').optional(),
     validatorError
   ],
+  markReadValidator: [
+    isValidReadInput('readStatus'),
+    validatorError
+  ]
 };
 
 export default novelValidator;

--- a/src/routes/novel.js
+++ b/src/routes/novel.js
@@ -1,12 +1,12 @@
 import express from 'express';
+import novelController from '../controllers/novelController';
 import middlewares from '../middlewares';
 import updateLikes from '../controllers/likesController';
-import novelController from '../controllers/novelController';
 
 const {
   novelValidator: {
     createNovelValidator, getNovelBySlugValidator, getNovelValidator,
-    createGenreValidator, getGenreValidator, editNovelValidator
+    createGenreValidator, getGenreValidator, editNovelValidator, markReadValidator
   },
   highlightValidator: { createHighlightValidator },
   verifyToken,
@@ -14,7 +14,8 @@ const {
 } = middlewares;
 const {
   createNovel, getNovels, createGenre, getGenres,
-  getSingleNovel, highlightNovel, postBookmark, fetchBookmarks, editNovel, deleteNovel
+  getSingleNovel, highlightNovel, postBookmark,
+  fetchBookmarks, editNovel, deleteNovel, toggleRead
 } = novelController;
 
 const novel = express.Router();
@@ -52,5 +53,8 @@ novel.get(`${NOVEL_URL}/:slug`, verifyToken, authorizeUser(['reader', 'author', 
 
 // Route to post highlight
 novel.post(`${NOVEL_URL}/:slug/highlight`, createHighlightValidator, verifyToken, highlightNovel);
+
+// Route to mark novel as read
+novel.patch(`${NOVEL_URL}/:slug/markread`, verifyToken, markReadValidator, authorizeUser(['author', 'admin', 'superadmin']), toggleRead);
 
 export default novel;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -16,7 +16,8 @@ const {
 } = middlewares;
 
 const {
-  getProfile, editProfile, createUser, listUsers, getUser, follow, unfollow, updateUser, deleteUser
+  getProfile, editProfile, createUser, listUsers, getUser,
+  follow, unfollow, updateUser, deleteUser, getReadingStats
 } = userController;
 
 const user = express.Router();
@@ -24,6 +25,7 @@ const user = express.Router();
 const USER_URL = '/users';
 const PROFILE_URL = '/profiles';
 
+user.get(`${PROFILE_URL}/readingstats`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), getReadingStats);
 // Route to get user profile by userId
 user.get(`${PROFILE_URL}/:userId`, verifyToken, authorizeUser(['reader', 'author', 'admin', 'superadmin']), profileValidator, getProfile);
 
@@ -39,5 +41,6 @@ user.post('/profiles/:userId/follow', followUserValidator, verifyToken, follow);
 user.delete('/profiles/:userId/follow', followUserValidator, verifyToken, unfollow);
 user.patch(`${USER_URL}/:userId`, validateUUID, validateUpdateUser, verifyToken, authorizeUser(['admin', 'superadmin']), updateUser);
 user.delete(`${USER_URL}/:userId`, validateUUID, verifyToken, authorizeUser(['superadmin']), deleteUser);
+
 
 export default user;

--- a/src/services/novelService.js
+++ b/src/services/novelService.js
@@ -3,7 +3,7 @@ import models from '../database/models';
 import helpers from '../helpers';
 
 const {
-  Genre, Novel, Like, User, Highlight, Bookmark
+  Genre, Novel, Like, User, Highlight, Bookmark, readStats
 } = models;
 const { generateReadTime } = helpers;
 
@@ -22,16 +22,6 @@ const findNovel = async (param) => {
 };
 
 /**
- * Finds a novel from the database by id
- * @param {string} param
- * @returns {object} a novel object
- */
-
-const findNovelById = param => Novel.findOne({
-  where: { id: param }
-});
-
-/**
  * Finds a novelLikes from the database by userid and novelId
  * @param {string} userId
  * @param {string} novelId
@@ -42,6 +32,16 @@ const findNovelLike = (userId, novelId) => Like.findOne({
   where: {
     [Op.and]: [{ userId }, { novelId }]
   }
+});
+
+/**
+ * Finds a novel from the database by id
+ * @param {string} param
+ * @returns {object} a novel object
+ */
+
+const findNovelById = param => Novel.findOne({
+  where: { id: param }
 });
 
 /**
@@ -267,6 +267,34 @@ const removeNovel = async ({ slug }, user) => {
   return true;
 };
 
+/**
+ *
+ * @param {object} userId - user id
+ * @param {object} novelId - novel id
+ * @param {object} readStatus - property from request body
+ * @returns {object} object
+ */
+const toggleReadStatus = async (userId, novelId, readStatus) => {
+  readStatus = readStatus === 'true';
+  if (!readStatus) {
+    await readStats.destroy({ where: { userId, novelId } });
+    return 'removed as read';
+  }
+  const read = await readStats.findOne({
+    where: { userId, novelId }
+  });
+  if (read) {
+    return 'marked as read';
+  }
+  await readStats.create({
+    userId, novelId
+  }, {
+    where: { userId }
+  });
+  return 'marked as read';
+};
+
+
 export default {
   findGenre,
   findNovel,
@@ -280,5 +308,6 @@ export default {
   highlightNovelText,
   getNovelHighlights,
   bookmarkNovel,
-  getAllBookmark
+  getAllBookmark,
+  toggleReadStatus,
 };

--- a/tests/mockData/novelMock.js
+++ b/tests/mockData/novelMock.js
@@ -28,6 +28,14 @@ const novelMock = {
   },
   emptyGenre: {
     name: ''
+  },
+  seedNovel1: {
+    id: '7f45df6d-7003-424f-86ec-1e2b36e2fd14',
+    slug: 'hancock',
+  },
+  seedNovel2: {
+    id: '8bd8c0ec-3b50-4228-bb71-e617c7b8d3b5',
+    slug: 'bancock',
   }
 };
 


### PR DESCRIPTION
#### What does this PR do?
- adds an endpoint for marking a novel as read
- add an endpoint for viewing read stats

#### Description of Task to be completed?
- Ensure the following endpoints are working

`PATCH  /api/v1/novels/<slug>/markread` 
`GET  /api/v1/profiles/readstats` 

#### How should this be manually tested?
To test manually on your local computer:
-  run the following commands.

```
# Clone this repository
$ git clone https://github.com/andela/dahlia-ah-backend.git

# Navigate to the application folder
$ cd dahlia-ah-backend

# Checkout the branch
$ git checkout feature/167165004/view-reading-stats
# Install dependencies
$ npm install

# Start the app in development mode
$ npm run dev:start
```
- check the `.env.example` file on the environmental variables to provide
- on Postman make an authorized request to the endpoints above

Note: See the screenshot below on how the  request/response should look
#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167165004 ](https://www.pivotaltracker.com/story/show/167165004 )

#### Screenshots
<img width="1164" alt="Screenshot 2019-08-21 at 10 01 32 AM" src="https://user-images.githubusercontent.com/42499892/63418281-be181380-c3fa-11e9-9f33-f8b30d9c2f06.png">
<img width="1033" alt="Screenshot 2019-08-21 at 9 59 54 AM" src="https://user-images.githubusercontent.com/42499892/63418280-be181380-c3fa-11e9-92f2-2c4cc141db5e.png">

#### API Flowchart
![API Flowchart read stats](https://user-images.githubusercontent.com/42499892/63418849-b311b300-c3fb-11e9-8fec-4e015827c576.png)

