### PR TITLE
#167942059 Users should be able to update and delete novels

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -364,6 +364,65 @@ paths:
                   error:
                     type: string
                     example: error occured
+  /novels/{slug}:
+    patch:
+      tags:
+        - Novels
+      summary: Update novel
+      parameters:
+      - name: "slug"
+        in: "path"
+        description: "slug of novel being updated"
+        required: true
+        schema:
+          $ref: '#/components/schemas/novelId'
+      security:
+      - token: []
+      requestBody:
+        description: fields containing novel data
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NovelInput'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/NovelInput'
+        required: true
+      responses:
+        200:
+          description: novel updated successfully
+        401:
+          description: Authentication failed
+        403:
+          description: you need permission
+        404:
+          description: Novel not found
+        500:
+          description: internal server error
+    delete:
+      tags:
+        - Novels
+      summary: Update novel
+      parameters:
+      - name: "slug"
+        in: "path"
+        description: "slug of novel being updated"
+        required: true
+        schema:
+          $ref: '#/components/schemas/novelId'
+      security:
+      - token: []
+      responses:
+        200:
+          description: novel deleted successfully
+        401:
+          description: Authentication failed
+        403:
+          description: you need permission
+        404:
+          description: Novel not found
+        500:
+          description: internal server error
   /novels/{slug}/like:
     post:
       tags:
@@ -410,7 +469,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StandardServerResponse'          
+                $ref: '#/components/schemas/StandardServerResponse'   
+      security:
+      - token: []                   
   /genres:
     post:
       tags:

--- a/src/controllers/novelController.js
+++ b/src/controllers/novelController.js
@@ -10,7 +10,8 @@ const {
   novelServices: {
     addNovel, findGenre, findNovel, findAllNovels,
     highlightNovelText, getNovelHighlights,
-    findNovelById, bookmarkNovel, getAllBookmark
+    findNovelById, bookmarkNovel, getAllBookmark,
+    updateNovel, removeNovel
   },
   notificationServices: { addNotification }
 } = services;
@@ -119,6 +120,36 @@ const getSingleNovel = async (request, response) => {
     });
   } catch (error) {
     return responseMessage(response, 500, { error: error.message });
+  }
+};
+
+/**
+ *
+ *
+ * @name editNovel
+ * @param {object} request
+ * @param {object} response
+ * @returns {object} json
+ */
+const editNovel = async (request, response) => {
+  const {
+    body,
+    params: slug,
+    user
+  } = request;
+  try {
+    const editedNovel = await updateNovel(slug, body, user);
+    if (editedNovel.error) {
+      return responseMessage(response, editedNovel.status, { error: editedNovel.error });
+    }
+    return responseMessage(response, 200, {
+      message: 'Novel updated successfully',
+      novel: {
+        ...editedNovel
+      }
+    });
+  } catch (error) {
+    responseMessage(response, 500, { error: error.message });
   }
 };
 
@@ -235,6 +266,31 @@ const fetchBookmarks = async (req, res) => {
   }
 };
 
+/**
+ *
+ * @name deleteNovel
+ * @param {object} request
+ * @param {object} response
+ * @returns {object} json
+ */
+const deleteNovel = async (request, response) => {
+  const {
+    params: slug,
+    user
+  } = request;
+  try {
+    const deletedNovel = await removeNovel(slug, user);
+    if (deletedNovel.error) {
+      return responseMessage(response, deletedNovel.status, { error: deletedNovel.error });
+    }
+    return responseMessage(response, 200, {
+      message: 'Novel deleted successfully'
+    });
+  } catch (error) {
+    responseMessage(response, 500, { error: error.message });
+  }
+};
+
 export default {
   createNovel,
   getNovels,
@@ -242,5 +298,7 @@ export default {
   highlightNovel,
   getSingleNovel,
   postBookmark,
-  fetchBookmarks
+  fetchBookmarks,
+  editNovel,
+  deleteNovel
 };

--- a/src/database/seeders/20190724090406-user.js
+++ b/src/database/seeders/20190724090406-user.js
@@ -208,5 +208,19 @@ export const up = queryInterface => queryInterface.bulkInsert('Users', [{
   isSubscribed: true,
   createdAt: new Date(),
   updatedAt: new Date()
+}, {
+  id: 'f4be7c34-7dcf-46b1-af21-95a2f34a4b0c',
+  firstName: 'Zen',
+  lastName: 'Daya',
+  email: 'zendaya@gmail.com',
+  password: bcrypt.hashSync('zendaya', 10),
+  bio: 'My name is Zen, Zen Daya',
+  avatarUrl: null,
+  phoneNo: null,
+  isVerified: true,
+  isSubscribed: false,
+  roleId: 'f2dec928-1ff9-421a-b77e-8998c8e2e720',
+  createdAt: new Date(),
+  updatedAt: new Date()
 }], {});
 export const down = queryInterface => queryInterface.bulkDelete('Users', null, {});

--- a/src/helpers/validator.js
+++ b/src/helpers/validator.js
@@ -105,6 +105,17 @@ const isNotEmpty = field => check(field)
   .withMessage(`${field} cannot be empty`);
 
 /**
+   * @param {String} field
+   * @returns {Object} - Express-validator
+   */
+const isOptional = field => check(field)
+  .optional()
+  .trim()
+  .not()
+  .isEmpty()
+  .withMessage(`${field} cannot be empty`);
+
+/**
    * @returns {Object} - Express-validator
    */
 const isNotEmptySlug = () => check('slug')
@@ -219,6 +230,7 @@ export default {
   isValidName,
   isValidPassword,
   isNotEmpty,
+  isOptional,
   isValidGenre,
   isNotEmptySlug,
   isValidComment,

--- a/src/middlewares/novelValidator.js
+++ b/src/middlewares/novelValidator.js
@@ -2,7 +2,7 @@ import validator from '../helpers/validator';
 import errorHandler from './errorHandler';
 
 const {
-  isNotEmpty, isValidGenre, isValidInt, isValidName, isNotEmptySlug
+  isNotEmpty, isValidGenre, isValidInt, isValidName, isNotEmptySlug, isOptional
 } = validator;
 
 const { validatorError } = errorHandler;
@@ -30,6 +30,13 @@ const novelValidator = {
   ],
   getNovelBySlugValidator: [
     isNotEmptySlug(),
+    validatorError
+  ],
+  editNovelValidator: [
+    isOptional('title'),
+    isOptional('description'),
+    isOptional('body'),
+    isOptional('genre'),
     validatorError
   ]
 };

--- a/src/routes/novel.js
+++ b/src/routes/novel.js
@@ -5,7 +5,8 @@ import novelController from '../controllers/novelController';
 
 const {
   novelValidator: {
-    createNovelValidator, getNovelBySlugValidator, getNovelValidator, genreValidator
+    createNovelValidator, getNovelBySlugValidator, getNovelValidator,
+    genreValidator, editNovelValidator
   },
   highlightValidator: { createHighlightValidator },
   verifyToken,
@@ -13,13 +14,19 @@ const {
 } = middlewares;
 const {
   createNovel, getNovels, createGenre,
-  getSingleNovel, highlightNovel, postBookmark, fetchBookmarks
+  getSingleNovel, highlightNovel, postBookmark, fetchBookmarks, editNovel, deleteNovel
 } = novelController;
 const novel = express.Router();
 const NOVEL_URL = '/novels';
 
 // Route to create a novel
 novel.post(`${NOVEL_URL}`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), createNovelValidator, createNovel);
+
+// Route to edit a novel
+novel.patch(`${NOVEL_URL}/:slug`, editNovelValidator, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), editNovel);
+
+// Route to delete a novel
+novel.delete(`${NOVEL_URL}/:slug`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), deleteNovel);
 
 // Route to like a novel
 novel.post(`${NOVEL_URL}/:slug/like`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), updateLikes);

--- a/src/services/novelService.js
+++ b/src/services/novelService.js
@@ -209,11 +209,71 @@ const findGenre = async (name) => {
   return genre;
 };
 
+/**
+ * @name updateNovel
+ * @param {string} slug
+ * @param {object} fields
+ * @param {object} user
+ * @returns {object} updated novel
+ */
+const updateNovel = async ({ slug }, fields, user) => {
+  const novel = await findNovel(slug);
+  if (!novel) {
+    return {
+      status: 404,
+      error: 'Novel not found'
+    };
+  }
+  if (novel.authorId !== user.id) {
+    return {
+      status: 403,
+      error: 'You cannot edit this book'
+    };
+  }
+  const updatedNovel = await Novel.update({
+    ...fields
+  }, {
+    where: { slug },
+    returning: true,
+    raw: true
+  });
+  return updatedNovel[1][0];
+};
+
+/**
+ *
+ * @name removeNovel
+ * @param {string} slug
+ * @param {object} user
+ * @returns {object} deleted novel
+ */
+const removeNovel = async ({ slug }, user) => {
+  const novel = await findNovel(slug);
+  if (!novel) {
+    return {
+      status: 404,
+      error: 'Novel not found'
+    };
+  }
+  if (novel.authorId !== user.id) {
+    return {
+      status: 403,
+      error: 'You cannot delete this book'
+    };
+  }
+  await Novel.destroy({
+    where: { slug }
+  });
+  return true;
+};
+
 export default {
   findGenre,
   findNovel,
   addNovel,
   findNovelById,
+  updateNovel,
+  removeNovel,
   findNovelLike,
   removeNovelLike,
   findAllNovels,

--- a/tests/mockData/userMock.js
+++ b/tests/mockData/userMock.js
@@ -133,6 +133,10 @@ export default {
     email: 'jamiefoxx@gmail.com',
     password: 'jamiefoxx'
   },
+  seededUser5: {
+    email: 'zendaya@gmail.com',
+    password: 'zendaya'
+  },
   validProfileLogin: {
     email: 'jamesbond@gmail.com',
     password: 'jamesbond'


### PR DESCRIPTION
#### Pivotal tracker story
[#167942059](https://www.pivotaltracker.com/story/show/167942059)

#### What does this PR do?
- Adds update novel endpoint
- Adds delete user endpoint

#### Summary of Task
- Users should be able to update and delete a novel

#### How can this be tested?
- URL: PATCH /api/v1/novels/:slug
- URL: DELETE /api/v1/novels/:slug
- Staging docs [ah-dahlia-staging](https://ah-dahlia-staging.herokuapp.com/docs)
- Production docs [ah-dahlia](https://ah-dahlia.herokuapp.com/docs)

#### Screenshots (if appropriate)
##### Flow chart
![Update and delete novels](https://user-images.githubusercontent.com/28323234/63559404-3e4c8f00-c549-11e9-8eae-a003fe6b8fb7.jpeg)

##### Response 
###### Update novel
![image](https://user-images.githubusercontent.com/28323234/63559561-2a555d00-c54a-11e9-93cf-0b0d4f7fd6f0.png)

###### Delete novel
![image](https://user-images.githubusercontent.com/28323234/63559570-36411f00-c54a-11e9-81a8-b57c4ad5a191.png)


