### PR TITLE
#168108145 Get All Genres

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -495,7 +495,59 @@ paths:
         409:
           description: resource already exists
         500:
-          description: internal server error                  
+          description: internal server error
+    get:
+      tags:
+        - Novels
+      summary: fetches all genres
+      description: fetches genres from the database
+      parameters:
+        - name: keyword
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: successfully fetched genres
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: successfully returned genres
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 1
+                        name:
+                          type: string
+                          example: action
+        401:
+          description: unauthorized access
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: invalid token
+        500:
+          description: server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: error occured
   /auth/login:
     post:
       tags:

--- a/src/controllers/novelController.js
+++ b/src/controllers/novelController.js
@@ -1,11 +1,13 @@
+import Sequelize from 'sequelize';
 import models from '../database/models';
 import services from '../services';
 import helpers from '../helpers';
 
+const { Op } = Sequelize;
 const {
   errorResponse, successResponse, novelHelpers: { extractNovels, filter }, responseMessage
 } = helpers;
-const { Novel } = models;
+const { Novel, Genre } = models;
 const {
   novelServices: {
     addNovel, findGenre, findNovel, findAllNovels,
@@ -15,8 +17,6 @@ const {
   },
   notificationServices: { addNotification }
 } = services;
-
-const { Genre } = models;
 
 /**
  * @name createNovel
@@ -265,6 +265,26 @@ const fetchBookmarks = async (req, res) => {
     return responseMessage(res, 500, { error: error.message });
   }
 };
+/**
+ * @description gets all genre
+ * @param {object} request express request object
+ * @param {object} response express response object
+ * @param {object} next express next argument
+ * @returns {json} json
+ */
+const getGenres = async (request, response) => {
+  const { keyword } = request.query;
+  const genreFilter = keyword ? { name: { [Op.iLike]: `%${keyword}%` } } : { id: { [Op.ne]: null } };
+  try {
+    const genreList = await Genre.findAll({ where: genreFilter, attributes: ['id', 'name'] });
+    return response.status(200).json({
+      message: 'successfully returned genres',
+      data: genreList
+    });
+  } catch (error) {
+    responseMessage(response, 500, { error: error.message });
+  }
+};
 
 /**
  *
@@ -295,6 +315,7 @@ export default {
   createNovel,
   getNovels,
   createGenre,
+  getGenres,
   highlightNovel,
   getSingleNovel,
   postBookmark,

--- a/src/middlewares/novelValidator.js
+++ b/src/middlewares/novelValidator.js
@@ -24,7 +24,7 @@ const novelValidator = {
     isNotEmpty('keyword').optional(),
     validatorError
   ],
-  genreValidator: [
+  createGenreValidator: [
     isValidName('name'),
     validatorError
   ],
@@ -38,7 +38,11 @@ const novelValidator = {
     isOptional('body'),
     isOptional('genre'),
     validatorError
-  ]
+  ],
+  getGenreValidator: [
+    isNotEmpty('keyword').optional(),
+    validatorError
+  ],
 };
 
 export default novelValidator;

--- a/src/routes/novel.js
+++ b/src/routes/novel.js
@@ -6,18 +6,20 @@ import novelController from '../controllers/novelController';
 const {
   novelValidator: {
     createNovelValidator, getNovelBySlugValidator, getNovelValidator,
-    genreValidator, editNovelValidator
+    createGenreValidator, getGenreValidator, editNovelValidator
   },
   highlightValidator: { createHighlightValidator },
   verifyToken,
   authorizeUser,
 } = middlewares;
 const {
-  createNovel, getNovels, createGenre,
+  createNovel, getNovels, createGenre, getGenres,
   getSingleNovel, highlightNovel, postBookmark, fetchBookmarks, editNovel, deleteNovel
 } = novelController;
+
 const novel = express.Router();
 const NOVEL_URL = '/novels';
+const GENRE_URL = '/genres';
 
 // Route to create a novel
 novel.post(`${NOVEL_URL}`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), createNovelValidator, createNovel);
@@ -32,7 +34,10 @@ novel.delete(`${NOVEL_URL}/:slug`, verifyToken, authorizeUser(['author', 'admin'
 novel.post(`${NOVEL_URL}/:slug/like`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), updateLikes);
 
 // Route to create a genre
-novel.post('/genres', verifyToken, authorizeUser(['author', 'admin', 'superadmin']), genreValidator, createGenre);
+novel.post(`${GENRE_URL}`, verifyToken, authorizeUser(['author', 'admin', 'superadmin']), createGenreValidator, createGenre);
+
+// Route to get all genres
+novel.get(`${GENRE_URL}`, verifyToken, getGenreValidator, getGenres);
 
 // Route to get bookmark
 


### PR DESCRIPTION
#### Pivotal tracker story
[#168108145](https://www.pivotaltracker.com/story/show/168108145)
#### What does this PR do?
Users should be able to view all genres
#### Summary of Task
- Create get genres controller
- Add test
- Add swagger documentation
#### How can this be tested?
- Use **git clone** to clone this repository to local branch
- Use **npm install** to download all necessary packages
- Ensure your database is created or you can use **sequelize db:create** if database does not exist
- Use **npm run test**  to test
- Go your POSTMAN and type **http://localhost:${PORT}/api/v1/genres** using a GET request to view all genres
#### Screenshots (if appropriate)
![Blank Diagramooo](https://user-images.githubusercontent.com/7049701/63713618-ea3af680-c837-11e9-98d4-f3027ee2cc35.png)


Flow Chart to Get all genres

<img width="834" alt="Screenshot 2019-08-26 at 3 43 48 PM" src="https://user-images.githubusercontent.com/7049701/63711528-8282ac80-c833-11e9-8936-3033df18ac72.png">

Screenshot of a successful request to get all genres